### PR TITLE
Add centralized ESI rate limiting buffer

### DIFF
--- a/analysis/structures.py
+++ b/analysis/structures.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import requests
 
 from util.utils import get_token, batched
+from util.esi_rate_limiter import esi_request
 from db.database import get_private_session, get_public_session
 from db.models import Structure, Asset, IndustryJob, Character
 
@@ -23,7 +24,8 @@ def safe_request(method, url, max_retries=5, backoff_factor=2, **kwargs):
     delay = 1
     for attempt in range(1, max_retries + 1):
         try:
-            resp = requests.request(method, url, timeout=30, **kwargs)
+            kwargs.setdefault("timeout", 30)
+            resp = esi_request(method, url, **kwargs)
             if resp.status_code == 420:
                 logger.warning(f"[RateLimit] 420 on {url}, sleeping 7s (attempt {attempt})")
                 time.sleep(7)

--- a/esi/corp_bookmarks.py
+++ b/esi/corp_bookmarks.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from util.utils import get_token
 from db.database import get_private_session
 from db.models import CorpBookmark
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ def fetch_corp_bookmarks(char_id: int, token: str) -> list:
     """Fetch corporation bookmarks using a character's access token."""
     url = f"{ESI}/characters/{char_id}/bookmarks/"
     headers = {"Authorization": f"Bearer {token}"}
-    resp = requests.get(url, headers=headers)
+    resp = esi_get(url, headers=headers)
     resp.raise_for_status()
     return resp.json()
 

--- a/esi/personal_assets.py
+++ b/esi/personal_assets.py
@@ -1,11 +1,12 @@
 # fetchers/private/personal_assets.py
 
-import requests
 import logging
+import requests
 
 from util.utils import get_token
 from db.database import get_private_session
 from db.models import Asset
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ def fetch_assets(char_id: int, access_token: str) -> list:
 
     while True:
         url = f"{ESI}/characters/{char_id}/assets/"
-        resp = requests.get(url, headers=headers, params={"page": page})
+        resp = esi_get(url, headers=headers, params={"page": page})
         resp.raise_for_status()
 
         data = resp.json()

--- a/esi/personal_bookmarks.py
+++ b/esi/personal_bookmarks.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from util.utils import get_token
 from db.database import get_private_session
 from db.models import PersonalBookmark
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ def fetch_bookmarks(char_id: int, access_token: str) -> list:
     """Fetch personal bookmarks for a character."""
     url = f"{ESI}/characters/{char_id}/bookmarks/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = esi_get(url, headers=headers)
     resp.raise_for_status()
     return resp.json()
 

--- a/esi/personal_industry_jobs.py
+++ b/esi/personal_industry_jobs.py
@@ -1,13 +1,14 @@
 # fetchers/private/personal_industry_jobs.py
 
-import requests
 import logging
+import requests
 from datetime import datetime
 
 from util.utils import get_token
 from util.auth import TokenDBManager
 from db.database import get_private_session
 from db.models import IndustryJob
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def fetch_industry_jobs(char_id: int, access_token: str) -> list:
     """Fetch active industry jobs for a character."""
     url = f"{ESI}/characters/{char_id}/industry/jobs/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = esi_get(url, headers=headers)
     resp.raise_for_status()
     return resp.json()
 

--- a/esi/personal_skills.py
+++ b/esi/personal_skills.py
@@ -1,13 +1,14 @@
 # fetchers/private/personal_skills.py
 
-import requests
 import logging
+import requests
 from datetime import datetime
 
 from db.database import get_private_session
 from db.models import Skill, SkillQueue
 from util.utils import get_token
 from util.auth import TokenDBManager
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def fetch_skills(char_id: int, access_token: str) -> list[dict]:
     """Fetch all skills for a character."""
     url = f"{ESI}/characters/{char_id}/skills/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = esi_get(url, headers=headers)
     resp.raise_for_status()
     return resp.json().get("skills", [])
 
@@ -27,7 +28,7 @@ def fetch_skillqueue(char_id: int, access_token: str) -> list[dict]:
     """Fetch skill queue for a character."""
     url = f"{ESI}/characters/{char_id}/skillqueue/"
     headers = {"Authorization": f"Bearer {access_token}"}
-    resp = requests.get(url, headers=headers)
+    resp = esi_get(url, headers=headers)
     resp.raise_for_status()
     return resp.json()
 

--- a/esi/personal_wallet.py
+++ b/esi/personal_wallet.py
@@ -1,12 +1,13 @@
 # esi/personal_wallet.py
 
-import requests
 import logging
+import requests
 from datetime import datetime
 
 from db.database import get_private_session
 from db.models import WalletJournal, WalletTransaction, WalletBalance
 from util.utils import get_token
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,7 @@ def fetch_wallet_journal(char_id: int, access_token: str) -> list:
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json"
     }
-    resp = requests.get(url, headers=headers, params=DATASOURCE)
+    resp = esi_get(url, headers=headers, params=DATASOURCE)
     resp.raise_for_status()
     return resp.json()
 
@@ -35,7 +36,7 @@ def fetch_wallet_transactions(char_id: int, access_token: str) -> list:
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json"
     }
-    resp = requests.get(url, headers=headers, params=DATASOURCE)
+    resp = esi_get(url, headers=headers, params=DATASOURCE)
     resp.raise_for_status()
     return resp.json()
 
@@ -48,7 +49,7 @@ def fetch_wallet_balance(char_id: int, access_token: str) -> float:
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json"
     }
-    resp = requests.get(url, headers=headers, params=DATASOURCE)
+    resp = esi_get(url, headers=headers, params=DATASOURCE)
     resp.raise_for_status()
     payload = resp.json()
 

--- a/esi/public/market_contracts.py
+++ b/esi/public/market_contracts.py
@@ -7,6 +7,7 @@ import requests
 from db.database import get_public_session
 from db.models import PublicContract
 from util.utils import get_all_region_ids
+from util.esi_rate_limiter import esi_get
 
 # ──────── Globals ───────────────────────────────────────────────────────────────
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ def fetch_public_contracts(region_id: int) -> list[dict]:
     url = f"{ESI}/contracts/public/{region_id}/"
 
     while True:
-        resp = requests.get(url, params={"page": page})
+        resp = esi_get(url, params={"page": page})
         if resp.status_code == 204:
             logger.info(f"[Contracts] Region {region_id}: no contracts (204) on page {page}")
             break

--- a/esi/public/market_station.py
+++ b/esi/public/market_station.py
@@ -9,6 +9,7 @@ import requests
 from db.database import get_public_session
 from db.models import MarketOrder
 from util.utils import get_all_region_ids
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ def fetch_with_retries(url: str, params: dict, max_retries: int = 3) -> requests
     backoff = 1
     for attempt in range(1, max_retries + 1):
         try:
-            resp = requests.get(url, headers=HEADERS, params=params)
+            resp = esi_get(url, headers=HEADERS, params=params)
             if resp.status_code == 420:
                 logger.warning(f"420 rate limit on {url}, sleeping 5s (attempt {attempt})")
                 time.sleep(5)
@@ -39,7 +40,7 @@ def fetch_with_retries(url: str, params: dict, max_retries: int = 3) -> requests
             logger.warning(f"Request error on {url} (attempt {attempt}): {e}")
             time.sleep(backoff)
             backoff *= 2
-    return requests.get(url, headers=HEADERS, params=params)
+    return esi_get(url, headers=HEADERS, params=params)
 
 def fetch_market_orders(region_id: int, page: int = 1) -> tuple[list, int]:
     """

--- a/esi/public/market_structure.py
+++ b/esi/public/market_structure.py
@@ -9,6 +9,7 @@ from db.database import get_public_session, get_private_session
 from db.models import Character, Structure, MarketStructure, MarketOrder
 from util.sde import region_id_from_system_id
 from util.utils import get_token
+from util.esi_rate_limiter import esi_get
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,7 @@ def fetch_structure_orders(structure_id: int, token: str, page: int = 1, retries
 
     for attempt in range(1, retries + 1):
         try:
-            resp = requests.get(url, headers=headers, params={**DATASOURCE, "page": page}, timeout=15)
+            resp = esi_get(url, headers=headers, params={**DATASOURCE, "page": page}, timeout=15)
 
             if resp.status_code in (403, 404):
                 logger.warning(f"[MarketFetch] Skipping {structure_id} page {page}: HTTP {resp.status_code}")

--- a/util/auth.py
+++ b/util/auth.py
@@ -14,6 +14,7 @@ from db.database import (
     initialize_public_database,
     get_public_session,
 )
+from util.esi_rate_limiter import esi_get
 
 # ─────── Globals ─────────────────────────────────────────────────────────────
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ def lookup_info(character_id: int):
     char_url = (
         f"https://esi.evetech.net/latest/characters/{character_id}/?datasource=tranquility"
     )
-    resp = requests.get(char_url)
+    resp = esi_get(char_url)
     resp.raise_for_status()
     char_data = resp.json()
 

--- a/util/esi_rate_limiter.py
+++ b/util/esi_rate_limiter.py
@@ -1,0 +1,226 @@
+"""Centralised ESI request buffering with floating window rate limiting support."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from typing import Deque, Dict, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# Token costs based on the ESI floating window specification.
+TOKEN_COSTS = {
+    2: 2,  # 2XX responses
+    3: 1,  # 3XX responses
+    4: 5,  # 4XX responses
+    5: 0,  # 5XX responses
+}
+
+DEFAULT_WINDOW_SECONDS = 15 * 60  # 15 minutes
+DEFAULT_TOKEN_LIMIT = 1800  # Conservative default: ~1 request / second for 2XX responses.
+
+
+def _token_cost_for_status(status_code: int) -> int:
+    """Return the token cost for a given HTTP status code."""
+
+    bucket = status_code // 100
+    return TOKEN_COSTS.get(bucket, 5)
+
+
+class _TokenBucket:
+    """Simple floating-window token bucket implementation."""
+
+    def __init__(self, limit: int = DEFAULT_TOKEN_LIMIT, window: int = DEFAULT_WINDOW_SECONDS) -> None:
+        self.limit = max(1, limit)
+        self.window = max(1, window)
+        self._entries: Deque[tuple[float, int]] = deque()
+        self._total = 0
+        self._lock = threading.Lock()
+
+    def configure(self, *, limit: Optional[int] = None, window: Optional[int] = None) -> None:
+        with self._lock:
+            if limit is not None and limit > 0:
+                if limit != self.limit:
+                    logger.debug("[RateLimiter] Updating limit: %s -> %s", self.limit, limit)
+                self.limit = limit
+            if window is not None and window > 0:
+                if window != self.window:
+                    logger.debug("[RateLimiter] Updating window: %s -> %s", self.window, window)
+                self.window = window
+
+    def _prune(self, now: float) -> None:
+        while self._entries and now - self._entries[0][0] >= self.window:
+            _, cost = self._entries.popleft()
+            self._total -= cost
+
+    def acquire(self, cost: int) -> None:
+        """Block until the bucket can accommodate *cost* tokens."""
+
+        cost = max(0, cost)
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                self._prune(now)
+                if self._total + cost <= self.limit:
+                    if cost:
+                        self._entries.append((now, cost))
+                        self._total += cost
+                    return
+                wait_time = self._entries[0][0] + self.window - now if self._entries else 1
+            if wait_time > 0:
+                time.sleep(min(wait_time, 1.0))
+
+    def adjust(self, delta: int) -> None:
+        """Adjust the token usage for the most recent request."""
+
+        if delta == 0:
+            return
+
+        with self._lock:
+            if delta > 0:
+                # Consume additional tokens immediately if available.
+                self.acquire(delta)
+            else:
+                # Return tokens by trimming from the newest entry.
+                to_return = -delta
+                while to_return and self._entries:
+                    ts, cost = self._entries.pop()
+                    remove = min(cost, to_return)
+                    remaining = cost - remove
+                    self._total -= remove
+                    to_return -= remove
+                    if remaining:
+                        self._entries.append((ts, remaining))
+                        self._total += remaining
+                        break
+
+
+class EsiRateLimiter:
+    """Serialize ESI requests through a single floating-window token bucket."""
+
+    def __init__(
+        self,
+        *,
+        token_limit: int = DEFAULT_TOKEN_LIMIT,
+        window_seconds: int = DEFAULT_WINDOW_SECONDS,
+        max_retries: int = 5,
+        default_retry_after: int = 2,
+    ) -> None:
+        self._bucket = _TokenBucket(limit=token_limit, window=window_seconds)
+        self._max_retries = max(1, max_retries)
+        self._default_retry_after = max(1, default_retry_after)
+
+    def request(self, method: str, url: str, **kwargs) -> requests.Response:
+        """Perform an HTTP request against ESI obeying rate limits and retries."""
+
+        attempt = 0
+        initial_cost = TOKEN_COSTS[2]
+
+        while True:
+            attempt += 1
+            self._bucket.acquire(initial_cost)
+            try:
+                response = requests.request(method, url, **kwargs)
+            except Exception:
+                # Return the reserved tokens since no response was obtained.
+                self._bucket.adjust(-initial_cost)
+                raise
+
+            # Adjust for the actual status cost if different from optimistic reservation.
+            actual_cost = _token_cost_for_status(response.status_code)
+            delta = actual_cost - initial_cost
+            if delta:
+                self._bucket.adjust(delta)
+
+            self._update_limits_from_headers(response.headers)
+
+            if response.status_code == 429 and attempt < self._max_retries:
+                retry_after = self._parse_retry_after(response.headers.get("Retry-After"))
+                logger.warning(
+                    "[RateLimiter] 429 received for %s %s. Sleeping %ss (attempt %s/%s)",
+                    method.upper(),
+                    url,
+                    retry_after,
+                    attempt,
+                    self._max_retries,
+                )
+                time.sleep(retry_after)
+                continue
+
+            return response
+
+    def _parse_retry_after(self, header_value: Optional[str]) -> int:
+        if not header_value:
+            return self._default_retry_after
+        try:
+            delay = int(float(header_value))
+            return max(self._default_retry_after, delay)
+        except (TypeError, ValueError):
+            return self._default_retry_after
+
+    def _update_limits_from_headers(self, headers: Dict[str, str]) -> None:
+        """Refresh the bucket configuration based on ESI rate limit headers if present."""
+
+        limit = self._extract_int(headers, "X-RateLimit-Limit")
+        if limit is None:
+            limit = self._extract_int(headers, "X-Esi-Rate-Limit-Limit")
+        window = self._extract_int(headers, "X-RateLimit-Window")
+        if window is None:
+            window = self._extract_int(headers, "X-Esi-Rate-Limit-Window")
+
+        if limit is not None or window is not None:
+            self._bucket.configure(limit=limit, window=window)
+
+    @staticmethod
+    def _extract_int(headers: Dict[str, str], key: str) -> Optional[int]:
+        value = headers.get(key)
+        if value is None:
+            return None
+        try:
+            # Some providers may supply comma-delimited values; use the first token.
+            value = value.split(",")[0]
+            return int(float(value))
+        except (ValueError, TypeError):
+            logger.debug("[RateLimiter] Failed to parse header %s=%s", key, value)
+            return None
+
+
+_GLOBAL_LIMITER: Optional[EsiRateLimiter] = None
+_GLOBAL_LOCK = threading.Lock()
+
+
+def get_esi_rate_limiter() -> EsiRateLimiter:
+    global _GLOBAL_LIMITER
+    if _GLOBAL_LIMITER is None:
+        with _GLOBAL_LOCK:
+            if _GLOBAL_LIMITER is None:
+                _GLOBAL_LIMITER = EsiRateLimiter()
+    return _GLOBAL_LIMITER
+
+
+def esi_request(method: str, url: str, **kwargs) -> requests.Response:
+    """Execute an HTTP request routed through the shared ESI rate limiter."""
+
+    limiter = get_esi_rate_limiter()
+    return limiter.request(method, url, **kwargs)
+
+
+def esi_get(url: str, **kwargs) -> requests.Response:
+    return esi_request("GET", url, **kwargs)
+
+
+def esi_post(url: str, **kwargs) -> requests.Response:
+    return esi_request("POST", url, **kwargs)
+
+
+def esi_put(url: str, **kwargs) -> requests.Response:
+    return esi_request("PUT", url, **kwargs)
+
+
+def esi_delete(url: str, **kwargs) -> requests.Response:
+    return esi_request("DELETE", url, **kwargs)
+

--- a/util/utils.py
+++ b/util/utils.py
@@ -16,6 +16,7 @@ import yaml
 from db.database import get_private_session
 from db.models import Character
 from util.auth import CredentialManager, TokenDBManager
+from util.esi_rate_limiter import esi_get, esi_post, esi_request
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +249,8 @@ def safe_request(method, url, **kwargs):
         print(f"[ESI] {method.upper()} {url} kwargs={kwargs}")
     for attempt in range(retries):
         try:
-            resp = requests.request(method, url, timeout=30, **kwargs)
+            kwargs.setdefault("timeout", 30)
+            resp = esi_request(method, url, **kwargs)
             if resp.status_code == 403:
                 logger.warning(f"Access forbidden (403) for {url}. Skipping retries.")
                 resp.raise_for_status()
@@ -269,7 +271,7 @@ def safe_request(method, url, **kwargs):
 def get_portrait(character_id: int):
     """ get esi portraits """
     url = f"{ESI_BASE}/characters/{character_id}/portrait/"
-    resp = requests.get(url, headers=HEADERS, params=DATASOURCE)
+    resp = esi_get(url, headers=HEADERS, params=DATASOURCE)
     resp.raise_for_status()
     if get_runtime_settings().trace_esi:
         print(f"[ESI] Portrait lookup for {character_id}: {resp.json()}")
@@ -284,14 +286,14 @@ def batched(iterable, batch_size):
 def get_all_region_ids():
     """Get all region IDs from ESI."""
     url = f"{ESI_BASE}/universe/regions/"
-    resp = requests.get(url, headers=HEADERS, params=DATASOURCE)
+    resp = esi_get(url, headers=HEADERS, params=DATASOURCE)
     resp.raise_for_status()
     return resp.json()
 
 def is_structure(structure_id: int) -> bool:
     """Check if a given ID is a structure via ESI."""
     url = f"{ESI_BASE}/universe/structures/{structure_id}/"
-    r = requests.get(url, headers=HEADERS, params=DATASOURCE)
+    r = esi_get(url, headers=HEADERS, params=DATASOURCE)
     return r
 
 def resolve_names_to_ids(names: list[str]) -> dict:
@@ -299,7 +301,7 @@ def resolve_names_to_ids(names: list[str]) -> dict:
     if not names:
         return {}
 
-    response = requests.post(
+    response = esi_post(
         f"{ESI_BASE}/universe/ids/",
         headers=HEADERS,
         params={"datasource": "tranquility", "language": os.getenv("LANGUAGE", "en")},


### PR DESCRIPTION
## Summary
- add a shared ESI rate limiter that enforces the floating window token rules and retries 429s automatically
- route all existing ESI callers through the buffered helpers so every request honours the limiter
- update authentication and utility helpers to use the new buffered request helpers

## Testing
- python -m compileall .


------
https://chatgpt.com/codex/tasks/task_e_6902a2b0ffcc832f9ec64a72808040b2