### PR TITLE
Add blueprint refresh endpoints and wallet update routes

### DIFF
--- a/esi/personal_blueprints.py
+++ b/esi/personal_blueprints.py
@@ -1,0 +1,142 @@
+"""ESI fetchers for personal blueprint inventories."""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+import requests
+
+from db.database import get_private_session
+from db.models import Blueprint
+from util.esi_rate_limiter import esi_get
+from util.utils import get_token
+
+logger = logging.getLogger(__name__)
+
+ESI = "https://esi.evetech.net/latest"
+DATASOURCE = {"datasource": "tranquility"}
+
+
+# ──────── Fetching ─────────────────────────────────────────────────────────────
+
+def fetch_blueprints(char_id: int, access_token: str) -> List[dict]:
+    """Fetch blueprint inventory for a character.
+
+    The ESI endpoint uses standard pagination semantics; iterate until the
+    server stops returning additional pages.
+    """
+
+    url = f"{ESI}/characters/{char_id}/blueprints/"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    }
+
+    page = 1
+    payload: List[dict] = []
+    while True:
+        params = {**DATASOURCE, "page": page}
+        response = esi_get(url, headers=headers, params=params)
+        response.raise_for_status()
+
+        batch = response.json() or []
+        if not isinstance(batch, list):
+            logger.warning(
+                "[blueprints] Unexpected payload for %s (page %s): %s",
+                char_id,
+                page,
+                batch,
+            )
+            break
+
+        payload.extend(batch)
+
+        total_pages = int(response.headers.get("x-pages", page))
+        if page >= total_pages:
+            break
+        page += 1
+
+    return payload
+
+
+# ──────── Storage ───────────────────────────────────────────────────────────────
+
+def _normalize_flag(raw_flag: object) -> str | None:
+    """Ensure the blueprint location flag is serialisable."""
+
+    if raw_flag is None:
+        return None
+    return str(raw_flag)
+
+
+def store_blueprints(owner_id: int, char_id: int, entries: Iterable[dict]) -> None:
+    """Persist blueprint entries for a character, replacing existing rows."""
+
+    session = get_private_session(owner_id)
+    try:
+        session.query(Blueprint).filter_by(character_id=char_id).delete()
+
+        for entry in entries:
+            session.add(
+                Blueprint(
+                    item_id=entry.get("item_id"),
+                    character_id=char_id,
+                    type_id=entry.get("type_id"),
+                    material_efficiency=entry.get("material_efficiency", 0),
+                    time_efficiency=entry.get("time_efficiency", 0),
+                    runs=entry.get("runs"),
+                    quantity=entry.get("quantity", 1),
+                    location_id=entry.get("location_id"),
+                    location_flag=_normalize_flag(entry.get("location_flag")),
+                )
+            )
+
+        session.commit()
+        logger.info(
+            "[blueprints] Stored %s blueprints for owner %s character %s",
+            session.query(Blueprint).filter_by(character_id=char_id).count(),
+            owner_id,
+            char_id,
+        )
+    except Exception:
+        session.rollback()
+        logger.exception(
+            "[blueprints] Failed storing blueprints for owner %s character %s",
+            owner_id,
+            char_id,
+        )
+        raise
+    finally:
+        session.close()
+
+
+# ──────── Orchestrator ───────────────────────────────────────────────────────────
+
+def fetch_all_blueprints(owner_id: int) -> None:
+    """Fetch and persist blueprint inventories for all of an owner's characters."""
+
+    tokens = get_token(owner_id)
+    for char_id, token_row in tokens.items():
+        logger.info("[blueprints] Fetching blueprints for %s", char_id)
+        try:
+            data = fetch_blueprints(char_id, token_row["access_token"])
+            store_blueprints(owner_id, char_id, data)
+            logger.info(
+                "[blueprints] Stored %s entries for owner %s character %s",
+                len(data),
+                owner_id,
+                char_id,
+            )
+        except requests.HTTPError as exc:
+            logger.error(
+                "[blueprints] HTTP error fetching blueprints for %s: %s",
+                char_id,
+                exc,
+            )
+        except Exception as exc:
+            logger.error(
+                "[blueprints] Unexpected error for %s: %s",
+                char_id,
+                exc,
+            )

--- a/tests/test_personal_blueprints.py
+++ b/tests/test_personal_blueprints.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from db import database
+from db.models import Blueprint
+from esi import personal_blueprints
+
+
+class PersonalBlueprintTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.private_dir = os.path.join(self.tempdir.name, "private")
+
+        os.environ["EVE_PRIVATE_DATABASE_FOLDER"] = self.private_dir
+        database.PRIVATE_DATA_FOLDER = self.private_dir
+        database._private_engines = {}
+        database._PrivateSessions = {}
+
+        self.owner_id = 4321
+        self.char_id = 987654
+        database.initialize_private_database(self.owner_id)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _fetch_rows(self) -> list[Blueprint]:
+        session = database.get_private_session(self.owner_id)
+        try:
+            return session.query(Blueprint).filter_by(character_id=self.char_id).all()
+        finally:
+            session.close()
+
+    def test_store_blueprints_replaces_existing_rows(self) -> None:
+        session = database.get_private_session(self.owner_id)
+        session.add(
+            Blueprint(
+                item_id=1,
+                character_id=self.char_id,
+                type_id=1001,
+                material_efficiency=2,
+                time_efficiency=4,
+                runs=1,
+                quantity=1,
+                location_id=500,
+                location_flag="Old",
+            )
+        )
+        session.commit()
+        session.close()
+
+        payload = [
+            {
+                "item_id": 42,
+                "type_id": 2002,
+                "material_efficiency": 10,
+                "time_efficiency": 20,
+                "runs": 8,
+                "quantity": 3,
+                "location_id": 123,
+                "location_flag": "CorpHangar",
+            }
+        ]
+
+        personal_blueprints.store_blueprints(self.owner_id, self.char_id, payload)
+
+        rows = self._fetch_rows()
+        self.assertEqual(len(rows), 1)
+        row = rows[0]
+        self.assertEqual(row.item_id, 42)
+        self.assertEqual(row.type_id, 2002)
+        self.assertEqual(row.material_efficiency, 10)
+        self.assertEqual(row.time_efficiency, 20)
+        self.assertEqual(row.runs, 8)
+        self.assertEqual(row.quantity, 3)
+        self.assertEqual(row.location_id, 123)
+        self.assertEqual(row.location_flag, "CorpHangar")
+
+    def test_fetch_all_blueprints_persists_results(self) -> None:
+        blueprint_payload = [
+            {
+                "item_id": 77,
+                "type_id": 3003,
+                "material_efficiency": 5,
+                "time_efficiency": 6,
+                "runs": 12,
+                "quantity": 1,
+                "location_id": 321,
+                "location_flag": "Hangar",
+            }
+        ]
+
+        with mock.patch.object(
+            personal_blueprints, "get_token", return_value={self.char_id: {"access_token": "abc"}}
+        ), mock.patch.object(
+            personal_blueprints, "fetch_blueprints", return_value=blueprint_payload
+        ) as fetch_mock:
+            personal_blueprints.fetch_all_blueprints(self.owner_id)
+            fetch_mock.assert_called_once_with(self.char_id, "abc")
+
+        rows = self._fetch_rows()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].item_id, 77)
+        self.assertEqual(rows[0].type_id, 3003)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webUI/personal_routes.py
+++ b/webUI/personal_routes.py
@@ -1,14 +1,21 @@
 # webUI/update_personal_routes.py
 
-from flask import Blueprint, redirect, url_for, session
 import logging
 
+from flask import Blueprint, redirect, url_for, session
+
 # Private fetchers
-from esi.personal_industry_jobs import fetch_all_industry
-from esi.personal_skills import fetch_all_skills
 from esi.personal_assets import fetch_all_assets
+from esi.personal_blueprints import fetch_all_blueprints
+from esi.personal_industry_jobs import fetch_all_industry
 from esi.personal_bookmarks import update_personal_bookmarks
-from esi.personal_wallet import fetch_all_wallets
+from esi.personal_skills import fetch_all_skills
+from esi.personal_wallet import (
+    fetch_all_balance as fetch_wallet_balances,
+    fetch_all_journals as fetch_wallet_journals,
+    fetch_all_transactions as fetch_wallet_transactions,
+    fetch_all_wallets,
+)
 
 
 # ──────── Setup ──────────────────────────────────────────────────────────────
@@ -49,6 +56,47 @@ def update_wallet():
     logger.info(f"[UpdatePersonal] Fetched wallet transactions for owner {owner_id}")
     return redirect(url_for("dashboard.home"))
 
+
+@update_personal_bp.route("/wallet/transactions")
+def update_wallet_transactions():
+    """Refresh only wallet transactions for linked characters."""
+
+    owner_id = session.get("owner_id")
+    if not owner_id:
+        return "Unauthorized", 401
+
+    fetch_wallet_transactions(owner_id)
+    logger.info(
+        f"[UpdatePersonal] Fetched wallet transactions for owner {owner_id}"
+    )
+    return redirect(url_for("dashboard.home"))
+
+
+@update_personal_bp.route("/wallet/journal")
+def update_wallet_journal():
+    """Refresh only wallet journal entries for linked characters."""
+
+    owner_id = session.get("owner_id")
+    if not owner_id:
+        return "Unauthorized", 401
+
+    fetch_wallet_journals(owner_id)
+    logger.info(f"[UpdatePersonal] Fetched wallet journal for owner {owner_id}")
+    return redirect(url_for("dashboard.home"))
+
+
+@update_personal_bp.route("/wallet/balance")
+def update_wallet_balance():
+    """Refresh wallet balances for linked characters."""
+
+    owner_id = session.get("owner_id")
+    if not owner_id:
+        return "Unauthorized", 401
+
+    fetch_wallet_balances(owner_id)
+    logger.info(f"[UpdatePersonal] Fetched wallet balance for owner {owner_id}")
+    return redirect(url_for("dashboard.home"))
+
 @update_personal_bp.route("/skills")
 def update_skills():
     """Trigger a refresh of personal skills."""
@@ -67,4 +115,17 @@ def update_bookmarks():
         return "Unauthorized", 401
     update_personal_bookmarks(owner_id)
     logger.info(f"[UpdatePersonal] Fetched bookmarks for owner {owner_id}")
+    return redirect(url_for("dashboard.home"))
+
+
+@update_personal_bp.route("/blueprints")
+def update_blueprints():
+    """Trigger a refresh of personal blueprints."""
+
+    owner_id = session.get("owner_id")
+    if not owner_id:
+        return "Unauthorized", 401
+
+    fetch_all_blueprints(owner_id)
+    logger.info(f"[UpdatePersonal] Fetched blueprints for owner {owner_id}")
     return redirect(url_for("dashboard.home"))

--- a/webUI/templates/dashboard.html
+++ b/webUI/templates/dashboard.html
@@ -322,8 +322,12 @@
                     </div>
                     <div class="action-chips">
                         <a class="chip" href="{{ url_for('update_personal.update_assets') }}">Assets</a>
+                        <a class="chip" href="{{ url_for('update_personal.update_blueprints') }}">Blueprints</a>
                         <a class="chip" href="{{ url_for('update_personal.update_industry') }}">Industry Jobs</a>
-                        <a class="chip" href="{{ url_for('update_personal.update_wallet') }}">Wallet</a>
+                        <a class="chip" href="{{ url_for('update_personal.update_wallet') }}">Wallet (All)</a>
+                        <a class="chip" href="{{ url_for('update_personal.update_wallet_transactions') }}">Wallet Txns</a>
+                        <a class="chip" href="{{ url_for('update_personal.update_wallet_journal') }}">Wallet Journal</a>
+                        <a class="chip" href="{{ url_for('update_personal.update_wallet_balance') }}">Wallet Balance</a>
                         <a class="chip" href="{{ url_for('update_personal.update_skills') }}">Skills</a>
                         <a class="chip" href="{{ url_for('update_personal.update_bookmarks') }}">Bookmarks</a>
                         <a class="chip" href="{{ url_for('update_public.update_public_sde') }}">Refresh SDE</a>


### PR DESCRIPTION
## Summary
- add a personal blueprint fetcher that persists inventory to each owner's database
- expose dedicated dashboard routes for blueprint syncs and granular wallet updates
- cover the new blueprint pipeline with unit tests to ensure storage and orchestration work as expected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690509957cbc832f91c3f597a63f09be