### PR TITLE
Enhance industry planner metrics and sorting

### DIFF
--- a/analysis/industry.py
+++ b/analysis/industry.py
@@ -41,6 +41,7 @@ class MaterialCost:
     adjusted_quantity: int
     price: float
     total_cost: float
+    available: bool
 
 
 @dataclass
@@ -53,6 +54,9 @@ class BlueprintLibraryEntry:
     total_runs: int
     me: int
     te: int
+    is_original: bool
+    available_runs: int | None
+    runs_display: str
     product_type_id: int
     product_name: str
     product_quantity: int
@@ -64,6 +68,8 @@ class BlueprintLibraryEntry:
     total_profit: float
     margin_percent: float
     isk_per_hour: float
+    can_build: bool
+    missing_materials: List[str]
     materials: List[MaterialCost] = field(default_factory=list)
 
 
@@ -78,6 +84,9 @@ class ManufacturingQueueItem:
     isk_per_hour: float
     total_time_hours: float
     margin_percent: float
+    me: int
+    te: int
+    is_original: bool
 
 
 @dataclass
@@ -255,7 +264,15 @@ def generate_industry_report(
                 "blueprint_total": 0,
                 "profitable_total": 0,
                 "plan_total": 0,
+                "craftable_total": 0,
+                "original_total": 0,
+                "copy_total": 0,
+                "average_me": 0.0,
+                "average_te": 0.0,
                 "missing_blueprints": [],
+                "total_profit": 0.0,
+                "average_isk_per_hour": 0.0,
+                "best_blueprint": None,
             }
             return IndustryReport(settings=settings, library=[], manufacturing_plan=[], summary=summary)
 
@@ -281,23 +298,37 @@ def generate_industry_report(
                 continue
 
             quantity = max(1, bp.quantity or 1)
-            available_runs = bp.runs or 0
-            if available_runs > 0:
-                runs_per_blueprint = min(available_runs, settings.runs_per_blueprint)
+            raw_runs = bp.runs
+            is_original = raw_runs is not None and raw_runs < 0
+            available_runs = None
+            if raw_runs is not None and raw_runs >= 0:
+                available_runs = raw_runs
+
+            if available_runs is not None:
+                runs_per_blueprint = max(0, min(available_runs, settings.runs_per_blueprint))
             else:
-                runs_per_blueprint = settings.runs_per_blueprint
-            total_runs = max(1, runs_per_blueprint * quantity)
+                runs_per_blueprint = max(0, settings.runs_per_blueprint)
+
+            total_runs = runs_per_blueprint * quantity
+            runs_display = "∞" if is_original else str(available_runs if available_runs is not None else runs_per_blueprint)
 
             time_per_run = _time_per_run(definition.manufacturing_time, bp.time_efficiency, settings)
-            total_time_hours = (time_per_run * total_runs) / max(1, settings.parallel_jobs) / 3600
+            total_time_hours = 0.0
+            if total_runs > 0:
+                total_time_hours = (time_per_run * total_runs) / max(1, settings.parallel_jobs) / 3600
 
             materials_breakdown: List[MaterialCost] = []
             material_cost_per_run = 0.0
+            missing_materials: List[str] = []
             for mat_type_id, base_qty in definition.materials:
                 adjusted_qty = _material_quantity(base_qty, bp.material_efficiency)
                 price = price_map.get(mat_type_id, 0.0)
-                total_cost = adjusted_qty * price
-                material_cost_per_run += total_cost
+                available = price > 0
+                if not available:
+                    missing_materials.append(name_from_type_id(mat_type_id))
+                total_cost = adjusted_qty * price if available else 0.0
+                if available:
+                    material_cost_per_run += total_cost
                 materials_breakdown.append(
                     MaterialCost(
                         type_id=mat_type_id,
@@ -306,6 +337,7 @@ def generate_industry_report(
                         adjusted_quantity=adjusted_qty,
                         price=price,
                         total_cost=total_cost,
+                        available=available,
                     )
                 )
 
@@ -315,10 +347,17 @@ def generate_industry_report(
             revenue_after_tax = revenue_per_run * (1 - tax_rate)
             job_cost = settings.job_cost_per_run if settings.include_job_cost else 0.0
 
-            profit_per_run = revenue_after_tax - material_cost_per_run - job_cost
-            total_profit = profit_per_run * total_runs
-            margin_percent = (profit_per_run / material_cost_per_run) if material_cost_per_run > 0 else 0.0
-            isk_per_hour = total_profit / total_time_hours if total_time_hours > 0 else 0.0
+            can_build = not missing_materials and product_price > 0 and total_runs > 0
+            if can_build:
+                profit_per_run = revenue_after_tax - material_cost_per_run - job_cost
+                total_profit = profit_per_run * total_runs
+                margin_percent = (profit_per_run / material_cost_per_run) if material_cost_per_run > 0 else 0.0
+                isk_per_hour = total_profit / total_time_hours if total_time_hours > 0 else 0.0
+            else:
+                profit_per_run = 0.0
+                total_profit = 0.0
+                margin_percent = 0.0
+                isk_per_hour = 0.0
 
             entry = BlueprintLibraryEntry(
                 blueprint_type_id=bp.type_id,
@@ -329,6 +368,9 @@ def generate_industry_report(
                 total_runs=total_runs,
                 me=bp.material_efficiency or 0,
                 te=bp.time_efficiency or 0,
+                is_original=is_original,
+                available_runs=available_runs,
+                runs_display=runs_display,
                 product_type_id=definition.product_type_id,
                 product_name=name_from_type_id(definition.product_type_id),
                 product_quantity=definition.product_quantity,
@@ -340,11 +382,13 @@ def generate_industry_report(
                 total_profit=total_profit,
                 margin_percent=margin_percent,
                 isk_per_hour=isk_per_hour,
+                can_build=can_build,
+                missing_materials=missing_materials,
                 materials=materials_breakdown,
             )
             library_entries.append(entry)
 
-        profitable_entries = [e for e in library_entries if e.profit_per_run > 0 and e.isk_per_hour > 0]
+        profitable_entries = [e for e in library_entries if e.can_build and e.profit_per_run > 0 and e.isk_per_hour > 0]
         margin_threshold = _coerce_tax(settings.minimum_margin)
         plan_candidates = [e for e in profitable_entries if e.margin_percent >= margin_threshold]
         plan_candidates.sort(key=lambda entry: entry.isk_per_hour, reverse=True)
@@ -360,6 +404,9 @@ def generate_industry_report(
                 isk_per_hour=entry.isk_per_hour,
                 total_time_hours=entry.total_time_hours,
                 margin_percent=entry.margin_percent,
+                me=entry.me,
+                te=entry.te,
+                is_original=entry.is_original,
             )
             for entry in plan_candidates
         ]
@@ -370,10 +417,20 @@ def generate_industry_report(
         if library_limit is not None:
             display_library = library_entries[:library_limit]
 
+        original_total = sum(1 for e in library_entries if e.is_original)
+        craftable_total = sum(1 for e in library_entries if e.can_build)
+        me_values = [e.me for e in library_entries]
+        te_values = [e.te for e in library_entries]
+
         summary: Dict[str, object] = {
             "blueprint_total": len(library_entries),
             "profitable_total": len(profitable_entries),
             "plan_total": len(plan_candidates),
+            "craftable_total": craftable_total,
+            "original_total": original_total,
+            "copy_total": len(library_entries) - original_total,
+            "average_me": statistics.mean(me_values) if me_values else 0.0,
+            "average_te": statistics.mean(te_values) if te_values else 0.0,
             "missing_blueprints": sorted(set(missing)),
             "total_profit": sum(e.total_profit for e in plan_candidates),
             "average_isk_per_hour": statistics.mean([e.isk_per_hour for e in plan_candidates]) if plan_candidates else 0.0,

--- a/webUI/templates/industry/dashboard.html
+++ b/webUI/templates/industry/dashboard.html
@@ -38,6 +38,32 @@
             {% endif %}
         </section>
 
+        <section class="card">
+            <h2>Blueprint Health</h2>
+            <div class="metrics">
+                <div class="metric">
+                    <span>Craftable Today</span>
+                    <strong>{{ summary.craftable_total or 0 }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Blueprint Originals</span>
+                    <strong>{{ summary.original_total or 0 }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Blueprint Copies</span>
+                    <strong>{{ summary.copy_total or 0 }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Average ME</span>
+                    <strong>{{ summary.average_me | default(0.0) | round(1) }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Average TE</span>
+                    <strong>{{ summary.average_te | default(0.0) | round(1) }}</strong>
+                </div>
+            </div>
+        </section>
+
         {% if summary.best_blueprint %}
             {% set top = summary.best_blueprint %}
             <section class="card">
@@ -50,6 +76,10 @@
                     <div class="metric">
                         <span>Product</span>
                         <strong>{{ top.product_name }}</strong>
+                    </div>
+                    <div class="metric">
+                        <span>Blueprint ME / TE</span>
+                        <strong>{{ top.me }} / {{ top.te }}</strong>
                     </div>
                     <div class="metric">
                         <span>ISK / hour</span>
@@ -68,14 +98,16 @@
                 <h2>Blueprint Library Preview</h2>
                 {% if report and report.library %}
                     <div class="table-wrapper">
-                        <table>
+                        <table data-sortable="true">
                             <thead>
                                 <tr>
-                                    <th>Blueprint</th>
-                                    <th>Product</th>
-                                    <th>Runs</th>
-                                    <th>Profit/run</th>
-                                    <th>ISK/hr</th>
+                                    <th data-type="string">Blueprint</th>
+                                    <th data-type="string">Product</th>
+                                    <th data-type="number">Runs</th>
+                                    <th data-type="number">ME</th>
+                                    <th data-type="number">TE</th>
+                                    <th data-type="number">Profit/run</th>
+                                    <th data-type="number">ISK/hr</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -83,7 +115,9 @@
                                     <tr>
                                         <td>{{ entry.blueprint_name }}</td>
                                         <td>{{ entry.product_name }}</td>
-                                        <td>{{ entry.total_runs }}</td>
+                                        <td data-sort-value="{{ entry.available_runs if entry.available_runs is not none else (10 ** 9) }}">{{ entry.runs_display }}</td>
+                                        <td data-sort-value="{{ entry.me }}">{{ entry.me }}</td>
+                                        <td data-sort-value="{{ entry.te }}">{{ entry.te }}</td>
                                         <td>{{ entry.profit_per_run | round(2) }}</td>
                                         <td>{{ entry.isk_per_hour | round(2) }}</td>
                                     </tr>

--- a/webUI/templates/industry/layout.html
+++ b/webUI/templates/industry/layout.html
@@ -132,8 +132,37 @@
             color: var(--text-muted);
         }
 
+        th.sortable {
+            cursor: pointer;
+            position: relative;
+        }
+
+        th.sortable::after {
+            content: "";
+            position: absolute;
+            right: 0.4rem;
+            top: 50%;
+            transform: translateY(-50%);
+            font-size: 0.6rem;
+            opacity: 0.4;
+        }
+
+        th.sortable[data-sort-active="true"][data-sort-direction="asc"]::after {
+            content: "▲";
+            opacity: 0.8;
+        }
+
+        th.sortable[data-sort-active="true"][data-sort-direction="desc"]::after {
+            content: "▼";
+            opacity: 0.8;
+        }
+
         tr:last-child td {
             border-bottom: none;
+        }
+
+        .materials-row td {
+            background: rgba(15, 23, 42, 0.35);
         }
 
         .badge {
@@ -312,5 +341,84 @@
         {% endwith %}
         {% block content %}{% endblock %}
     </main>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const parseValue = (raw, type) => {
+                if (type === 'number' || type === 'percent') {
+                    if (raw === undefined || raw === null) {
+                        return 0;
+                    }
+                    const normalised = String(raw).replace(/[^0-9.\-]/g, '');
+                    const parsed = parseFloat(normalised);
+                    return Number.isNaN(parsed) ? 0 : parsed;
+                }
+                return String(raw ?? '').trim().toLowerCase();
+            };
+
+            const getCellValue = (row, index, type) => {
+                const cell = row.children[index];
+                if (!cell) {
+                    return type === 'number' ? 0 : '';
+                }
+                const raw = cell.dataset.sortValue !== undefined ? cell.dataset.sortValue : cell.textContent;
+                return parseValue(raw, type);
+            };
+
+            document.querySelectorAll('table[data-sortable="true"]').forEach((table) => {
+                const tbody = table.tBodies[0];
+                if (!tbody) {
+                    return;
+                }
+
+                const entrySelector = table.dataset.entrySelector || 'tr';
+                const getEntryRows = () => Array.from(tbody.querySelectorAll(entrySelector));
+
+                table.querySelectorAll('th').forEach((th, index) => {
+                    const type = th.dataset.type || 'string';
+                    th.dataset.type = type;
+                    th.classList.add('sortable');
+
+                    th.addEventListener('click', () => {
+                        const nextDirection = th.dataset.sortDirection === 'asc' ? 'desc' : 'asc';
+
+                        table.querySelectorAll('th.sortable').forEach((header) => {
+                            if (header !== th) {
+                                header.removeAttribute('data-sort-direction');
+                                header.removeAttribute('data-sort-active');
+                            }
+                        });
+
+                        th.dataset.sortDirection = nextDirection;
+                        th.dataset.sortActive = 'true';
+
+                        const rows = getEntryRows();
+                        const multiplier = nextDirection === 'asc' ? 1 : -1;
+
+                        rows.sort((a, b) => {
+                            const aValue = getCellValue(a, index, th.dataset.type || 'string');
+                            const bValue = getCellValue(b, index, th.dataset.type || 'string');
+                            if (aValue < bValue) {
+                                return -1 * multiplier;
+                            }
+                            if (aValue > bValue) {
+                                return 1 * multiplier;
+                            }
+                            return 0;
+                        });
+
+                        rows.forEach((row) => {
+                            tbody.appendChild(row);
+                            const detailsId = row.dataset.entryId;
+                            if (detailsId) {
+                                tbody.querySelectorAll(`tr[data-details-for="${detailsId}"]`).forEach((detail) => {
+                                    tbody.appendChild(detail);
+                                });
+                            }
+                        });
+                    });
+                });
+            });
+        });
+    </script>
 </body>
 </html>

--- a/webUI/templates/industry/library.html
+++ b/webUI/templates/industry/library.html
@@ -23,49 +23,75 @@
                     <span>Plan Ready</span>
                     <strong>{{ report.summary.plan_total }}</strong>
                 </div>
+                <div class="metric">
+                    <span>Craftable Today</span>
+                    <strong>{{ report.summary.craftable_total }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Avg ME / TE</span>
+                    <strong>{{ report.summary.average_me | round(1) }} / {{ report.summary.average_te | round(1) }}</strong>
+                </div>
             </div>
         </section>
         <section class="card">
             <h2>Blueprint Inventory</h2>
             <div class="table-wrapper">
-                <table>
+                <table data-sortable="true" data-entry-selector="tr[data-entry-row='true']">
                     <thead>
                         <tr>
-                            <th>Blueprint</th>
-                            <th>Product</th>
-                            <th>Character</th>
-                            <th>Runs</th>
-                            <th>ME</th>
-                            <th>TE</th>
-                            <th>Material Cost/run</th>
-                            <th>Revenue/run</th>
-                            <th>Profit/run</th>
-                            <th>ISK/hr</th>
+                            <th data-type="string">Blueprint</th>
+                            <th data-type="string">Product</th>
+                            <th data-type="string">Character</th>
+                            <th data-type="number">Runs</th>
+                            <th data-type="number">ME</th>
+                            <th data-type="number">TE</th>
+                            <th data-type="number">Material Cost/run</th>
+                            <th data-type="number">Revenue/run</th>
+                            <th data-type="number">Profit/run</th>
+                            <th data-type="number">ISK/hr</th>
+                            <th data-type="string">Status</th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for entry in report.library %}
-                            <tr>
+                            <tr data-entry-row="true" data-entry-id="{{ entry.blueprint_type_id }}">
                                 <td>{{ entry.blueprint_name }}</td>
                                 <td>{{ entry.product_name }}</td>
                                 <td>{{ entry.character_name }}</td>
-                                <td>{{ entry.total_runs }}</td>
-                                <td>{{ entry.me }}</td>
-                                <td>{{ entry.te }}</td>
-                                <td>{{ entry.material_cost_per_run | round(2) }}</td>
-                                <td>{{ entry.revenue_per_run | round(2) }}</td>
-                                <td>{{ entry.profit_per_run | round(2) }}</td>
-                                <td>{{ entry.isk_per_hour | round(2) }}</td>
+                                <td data-sort-value="{{ entry.available_runs if entry.available_runs is not none else (10 ** 9) }}">{{ entry.runs_display }}</td>
+                                <td data-sort-value="{{ entry.me }}">{{ entry.me }}</td>
+                                <td data-sort-value="{{ entry.te }}">{{ entry.te }}</td>
+                                <td data-sort-value="{{ entry.material_cost_per_run }}">{{ entry.material_cost_per_run | round(2) }}</td>
+                                <td data-sort-value="{{ entry.revenue_per_run }}">{{ entry.revenue_per_run | round(2) }}</td>
+                                <td data-sort-value="{{ entry.profit_per_run }}">{{ entry.profit_per_run | round(2) }}</td>
+                                <td data-sort-value="{{ entry.isk_per_hour }}">{{ entry.isk_per_hour | round(2) }}</td>
+                                <td>
+                                    {% if entry.can_build %}
+                                        <span class="badge success">Ready</span>
+                                    {% elif entry.total_runs == 0 %}
+                                        <span class="badge danger">No Runs Available</span>
+                                    {% else %}
+                                        <span class="badge danger">Missing Inputs</span>
+                                    {% endif %}
+                                </td>
                             </tr>
                             {% if entry.materials %}
-                                <tr>
-                                    <td colspan="10">
+                                <tr class="materials-row" data-details-for="{{ entry.blueprint_type_id }}">
+                                    <td colspan="11">
                                         <strong>Materials per run</strong>
                                         <ul>
                                             {% for mat in entry.materials %}
-                                                <li>{{ mat.name }} — {{ mat.adjusted_quantity }} units @ {{ mat.price | round(2) }} ISK ({{ mat.total_cost | round(2) }} ISK)</li>
+                                                <li>
+                                                    {{ mat.name }} — {{ mat.adjusted_quantity }} units @ {{ mat.price | round(2) }} ISK ({{ mat.total_cost | round(2) }} ISK)
+                                                    {% if not mat.available %}
+                                                        <span class="badge danger">No market price</span>
+                                                    {% endif %}
+                                                </li>
                                             {% endfor %}
                                         </ul>
+                                        {% if entry.missing_materials %}
+                                            <p class="badge danger">Missing inputs: {{ entry.missing_materials | join(', ') }}</p>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endif %}

--- a/webUI/templates/industry/manufacturing.html
+++ b/webUI/templates/industry/manufacturing.html
@@ -9,18 +9,45 @@
         </div>
     {% else %}
         <section class="card">
+            <h2>Manufacturing Snapshot</h2>
+            <div class="metrics">
+                <div class="metric">
+                    <span>Queued Jobs</span>
+                    <strong>{{ report.manufacturing_plan | length }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Total Profit (ISK)</span>
+                    <strong>{{ report.summary.total_profit | round(2) }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Average ISK / hour</span>
+                    <strong>{{ report.summary.average_isk_per_hour | round(2) }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Blueprint Originals</span>
+                    <strong>{{ report.summary.original_total }}</strong>
+                </div>
+                <div class="metric">
+                    <span>Avg ME / TE</span>
+                    <strong>{{ report.summary.average_me | round(1) }} / {{ report.summary.average_te | round(1) }}</strong>
+                </div>
+            </div>
+        </section>
+        <section class="card">
             <h2>Production Opportunities</h2>
             <div class="table-wrapper">
-                <table>
+                <table data-sortable="true">
                     <thead>
                         <tr>
-                            <th>Product</th>
-                            <th>Blueprint</th>
-                            <th>Runs</th>
-                            <th>Total Time (hrs)</th>
-                            <th>Total Profit</th>
-                            <th>ISK/hr</th>
-                            <th>Margin</th>
+                            <th data-type="string">Product</th>
+                            <th data-type="string">Blueprint</th>
+                            <th data-type="number">ME</th>
+                            <th data-type="number">TE</th>
+                            <th data-type="number">Runs</th>
+                            <th data-type="number">Total Time (hrs)</th>
+                            <th data-type="number">Total Profit</th>
+                            <th data-type="number">ISK/hr</th>
+                            <th data-type="number">Margin %</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -28,11 +55,13 @@
                             <tr>
                                 <td>{{ job.product_name }}</td>
                                 <td>{{ job.blueprint_name }}</td>
-                                <td>{{ job.total_runs }}</td>
-                                <td>{{ job.total_time_hours | round(2) }}</td>
-                                <td>{{ job.total_profit | round(2) }}</td>
-                                <td>{{ job.isk_per_hour | round(2) }}</td>
-                                <td>{{ (job.margin_percent * 100) | round(2) }}%</td>
+                                <td data-sort-value="{{ job.me }}">{{ job.me }}</td>
+                                <td data-sort-value="{{ job.te }}">{{ job.te }}</td>
+                                <td data-sort-value="{{ job.total_runs if not job.is_original else (10 ** 9) }}">{{ '∞' if job.is_original else job.total_runs }}</td>
+                                <td data-sort-value="{{ job.total_time_hours }}">{{ job.total_time_hours | round(2) }}</td>
+                                <td data-sort-value="{{ job.total_profit }}">{{ job.total_profit | round(2) }}</td>
+                                <td data-sort-value="{{ job.isk_per_hour }}">{{ job.isk_per_hour | round(2) }}</td>
+                                <td data-sort-value="{{ job.margin_percent }}">{{ (job.margin_percent * 100) | round(2) }}%</td>
                             </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
## Summary
- include blueprint material and time efficiency, run availability, and craftability in industry calculations
- block uncraftable blueprints from profitability metrics and surface missing input prices in the UI
- add sortable tables plus new health and snapshot sections across industry overview, library, and manufacturing views

## Testing
- pytest *(fails: missing optional dependency `sqlalchemy` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_69053614ee68832fb29430d30029bb3e