### PR TITLE
Revamp blueprint library UI and build-vs-buy metrics

### DIFF
--- a/analysis/industry.py
+++ b/analysis/industry.py
@@ -43,6 +43,11 @@ class MaterialCost:
     price: float
     total_cost: float
     available: bool
+    buildable: bool = False
+    build_cost_per_unit: float | None = None
+    build_cost_total: float | None = None
+    savings_vs_market: float | None = None
+    build_preferred: bool = False
 
 
 @dataclass
@@ -309,6 +314,10 @@ def generate_industry_report(
                 "total_profit": 0.0,
                 "average_isk_per_hour": 0.0,
                 "best_blueprint": None,
+                "materials_with_build_option": 0,
+                "materials_build_cheaper": 0,
+                "average_build_savings": 0.0,
+                "total_build_savings": 0.0,
             }
             return IndustryReport(settings=settings, library=[], manufacturing_plan=[], summary=summary)
 
@@ -357,16 +366,21 @@ def generate_industry_report(
             materials_breakdown: List[MaterialCost] = []
             material_cost_per_run = 0.0
             missing_materials: List[str] = []
+            market_label = "sell orders" if settings.price_source == "sell" else "buy orders"
             for mat_type_id, base_qty in definition.materials:
                 adjusted_qty = _material_quantity(base_qty, bp.material_efficiency)
                 price_info = price_map.get(mat_type_id)
                 price = 0.0
                 available = False
                 if price_info:
-                    price = price_info.best_sell
-                    available = price_info.sell_order_count > 0 or price_info.override
+                    if settings.price_source == "buy":
+                        price = price_info.best_buy
+                        available = price_info.buy_order_count > 0 or price_info.override
+                    else:
+                        price = price_info.best_sell
+                        available = price_info.sell_order_count > 0 or price_info.override
                 if not available:
-                    missing_materials.append(f"{name_from_type_id(mat_type_id)} sell orders")
+                    missing_materials.append(f"{name_from_type_id(mat_type_id)} {market_label}")
                 total_cost = adjusted_qty * price if available else 0.0
                 if available:
                     material_cost_per_run += total_cost
@@ -475,6 +489,35 @@ def generate_industry_report(
         else:
             plan = aggregated_plan
 
+        product_index = {entry.product_type_id: entry for entry in library_entries}
+        component_job_cost = settings.job_cost_per_run if settings.include_job_cost else 0.0
+        for entry in library_entries:
+            for material in entry.materials:
+                component_entry = product_index.get(material.type_id)
+                if component_entry and component_entry.total_runs > 0:
+                    per_run_cost = component_entry.material_cost_per_run + component_job_cost
+                    per_unit_cost = per_run_cost / max(1, component_entry.product_quantity)
+                    total_build_cost = per_unit_cost * material.adjusted_quantity
+                    material.buildable = True
+                    material.build_cost_per_unit = per_unit_cost
+                    material.build_cost_total = total_build_cost
+                    savings = None
+                    if material.total_cost > 0:
+                        savings = material.total_cost - total_build_cost
+                    elif not material.available:
+                        savings = None
+                    material.savings_vs_market = savings
+                    if savings is not None and savings > 0:
+                        material.build_preferred = True
+                    elif not material.available:
+                        material.build_preferred = True
+                else:
+                    material.buildable = False
+                    material.build_cost_per_unit = None
+                    material.build_cost_total = None
+                    material.savings_vs_market = None
+                    material.build_preferred = False
+
         display_library = library_entries
         if library_limit is not None:
             display_library = library_entries[:library_limit]
@@ -485,6 +528,18 @@ def generate_industry_report(
         te_values = [e.te for e in library_entries]
 
         buildable_entries = [e for e in library_entries if e.can_build]
+
+        materials_with_build_option = 0
+        materials_build_cheaper = 0
+        build_savings: List[float] = []
+        for entry in library_entries:
+            for material in entry.materials:
+                if material.buildable:
+                    materials_with_build_option += 1
+                    if material.build_preferred:
+                        materials_build_cheaper += 1
+                    if material.savings_vs_market is not None and material.savings_vs_market > 0:
+                        build_savings.append(material.savings_vs_market)
 
         summary: Dict[str, object] = {
             "blueprint_total": len(library_entries),
@@ -501,6 +556,10 @@ def generate_industry_report(
             "average_isk_per_hour": statistics.mean([item.isk_per_hour for item in aggregated_plan]) if aggregated_plan else 0.0,
             "best_blueprint": plan_candidates[0] if plan_candidates else None,
             "unbuildable_total": sum(1 for e in library_entries if not e.can_build),
+            "materials_with_build_option": materials_with_build_option,
+            "materials_build_cheaper": materials_build_cheaper,
+            "average_build_savings": statistics.mean(build_savings) if build_savings else 0.0,
+            "total_build_savings": sum(build_savings) if build_savings else 0.0,
         }
 
         return IndustryReport(settings=settings, library=display_library, manufacturing_plan=plan, summary=summary)

--- a/webUI/industry.py
+++ b/webUI/industry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import asdict
+
 from flask import (Blueprint, redirect, render_template, request, session,
                    url_for, flash)
 
@@ -50,10 +53,18 @@ def library():
     settings = load_manufacturing_settings(owner_id)
     report = generate_industry_report(owner_id, settings, library_limit=None, plan_limit=10)
 
+    library_data_json = "[]"
+    selected_entry = None
+    if report and report.library:
+        library_data_json = json.dumps([asdict(entry) for entry in report.library])
+        selected_entry = report.library[0]
+
     return render_template(
         "industry/library.html",
         settings=settings,
         report=report,
+        selected_entry=selected_entry,
+        library_data_json=library_data_json,
     )
 
 

--- a/webUI/templates/industry/layout.html
+++ b/webUI/templates/industry/layout.html
@@ -441,6 +441,213 @@
                     });
                 });
             });
+
+            const detailScript = document.getElementById('library-data');
+            const detailRoot = document.getElementById('library-detail');
+            if (detailScript && detailRoot) {
+                let entries = [];
+                try {
+                    entries = JSON.parse(detailScript.textContent || '[]');
+                } catch (error) {
+                    console.error('Failed to parse library data payload', error);
+                }
+
+                if (entries.length > 0) {
+                    const entryById = new Map(entries.map((entry) => [String(entry.blueprint_type_id), entry]));
+                    const rows = Array.from(document.querySelectorAll('tr[data-entry-row="true"]'));
+
+                    const field = (selector) => detailRoot.querySelector(`[data-field="${selector}"]`);
+                    const materialsBody = detailRoot.querySelector('[data-materials-body]');
+                    const missingContainer = detailRoot.querySelector('[data-missing-list]');
+
+                    const toNumber = (value) => {
+                        const number = Number(value);
+                        return Number.isFinite(number) ? number : 0;
+                    };
+
+                    const formatNumber = (value, options = {}) => {
+                        const number = Number(value);
+                        if (!Number.isFinite(number)) {
+                            return '—';
+                        }
+                        return number.toLocaleString(undefined, options);
+                    };
+
+                    const formatCurrency = (value) => formatNumber(value, {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                    });
+
+                    const formatPercent = (value) => {
+                        const number = Number(value);
+                        if (!Number.isFinite(number)) {
+                            return '—';
+                        }
+                        return `${(number * 100).toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                        })}%`;
+                    };
+
+                    const formatHours = (value) => {
+                        const number = Number(value);
+                        if (!Number.isFinite(number)) {
+                            return '—';
+                        }
+                        return `${number.toLocaleString(undefined, {
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2,
+                        })} h`;
+                    };
+
+                    const updateStatusBadge = (entry) => {
+                        const badge = field('status-badge');
+                        if (!badge) {
+                            return;
+                        }
+                        badge.classList.remove('success', 'danger', 'neutral');
+                        if (entry.can_build) {
+                            badge.classList.add('success');
+                            badge.textContent = 'Build Ready';
+                        } else if (entry.total_runs === 0) {
+                            badge.classList.add('danger');
+                            badge.textContent = 'No Runs Available';
+                        } else {
+                            badge.classList.add('danger');
+                            badge.textContent = 'Missing Inputs';
+                        }
+                    };
+
+                    const renderMaterials = (entry) => {
+                        if (!materialsBody) {
+                            return;
+                        }
+                        const rowsHtml = (entry.materials || []).map((material) => {
+                            const classes = [];
+                            if (material.build_preferred) {
+                                classes.push('build-preferred');
+                            } else if (material.savings_vs_market !== null && material.savings_vs_market < 0) {
+                                classes.push('build-more-expensive');
+                            }
+                            const hasMarket = Boolean(material.available);
+                            const marketUnit = hasMarket ? formatCurrency(material.price) : '—';
+                            const marketTotal = hasMarket ? formatCurrency(material.total_cost) : '—';
+                            const buildUnit = material.build_cost_per_unit !== null && material.build_cost_per_unit !== undefined
+                                ? formatCurrency(material.build_cost_per_unit)
+                                : '—';
+                            const buildTotal = material.build_cost_total !== null && material.build_cost_total !== undefined
+                                ? formatCurrency(material.build_cost_total)
+                                : '—';
+                            const savings = material.savings_vs_market !== null && material.savings_vs_market !== undefined
+                                ? formatCurrency(material.savings_vs_market)
+                                : '—';
+                            return `
+                                <tr class="${classes.join(' ')}">
+                                    <td>${material.name}</td>
+                                    <td class="numeric">${toNumber(material.adjusted_quantity).toLocaleString()}</td>
+                                    <td class="numeric">${marketUnit}</td>
+                                    <td class="numeric">${marketTotal}</td>
+                                    <td class="numeric">${buildUnit}</td>
+                                    <td class="numeric">${buildTotal}</td>
+                                    <td class="numeric">${savings}</td>
+                                </tr>
+                            `;
+                        }).join('');
+                        materialsBody.innerHTML = rowsHtml;
+
+                        if (missingContainer) {
+                            if (entry.missing_materials && entry.missing_materials.length > 0) {
+                                missingContainer.textContent = `Missing inputs: ${entry.missing_materials.join(', ')}`;
+                                missingContainer.classList.add('danger');
+                            } else {
+                                missingContainer.textContent = 'All required materials have market coverage.';
+                                missingContainer.classList.remove('danger');
+                            }
+                        }
+                    };
+
+                    const updateDetail = (entry) => {
+                        detailRoot.dataset.hasSelection = 'true';
+                        const nameField = field('blueprint-name');
+                        if (nameField) {
+                            nameField.textContent = entry.blueprint_name;
+                        }
+                        const productLine = field('product-line');
+                        if (productLine) {
+                            productLine.textContent = `${entry.product_name} • ${entry.product_quantity} units per run`;
+                        }
+                        const kind = field('blueprint-kind');
+                        if (kind) {
+                            kind.textContent = entry.is_original ? 'Original Blueprint' : 'Copy Blueprint';
+                            kind.classList.remove('success', 'danger', 'neutral');
+                            kind.classList.add(entry.is_original ? 'success' : 'neutral');
+                        }
+                        const characterField = field('character-name');
+                        if (characterField) {
+                            characterField.textContent = entry.character_name;
+                        }
+                        const runsField = field('runs');
+                        if (runsField) {
+                            runsField.textContent = entry.runs_display;
+                        }
+                        const researchField = field('research');
+                        if (researchField) {
+                            researchField.textContent = `${entry.me} / ${entry.te}`;
+                        }
+                        const totalTimeField = field('total-time');
+                        if (totalTimeField) {
+                            totalTimeField.textContent = formatHours(entry.total_time_hours);
+                        }
+                        const materialCostField = field('material-cost');
+                        if (materialCostField) {
+                            materialCostField.textContent = formatCurrency(entry.material_cost_per_run);
+                        }
+                        const revenueField = field('revenue');
+                        if (revenueField) {
+                            revenueField.textContent = formatCurrency(entry.revenue_per_run);
+                        }
+                        const profitField = field('profit');
+                        if (profitField) {
+                            profitField.textContent = formatCurrency(entry.profit_per_run);
+                        }
+                        const iskField = field('isk-per-hour');
+                        if (iskField) {
+                            iskField.textContent = formatCurrency(entry.isk_per_hour);
+                        }
+                        const totalProfitField = field('total-profit');
+                        if (totalProfitField) {
+                            totalProfitField.textContent = formatCurrency(entry.total_profit);
+                        }
+                        const marginField = field('margin');
+                        if (marginField) {
+                            marginField.textContent = formatPercent(entry.margin_percent);
+                        }
+                        updateStatusBadge(entry);
+                        renderMaterials(entry);
+                    };
+
+                    const selectRow = (row) => {
+                        const entryId = row.dataset.entryId;
+                        if (!entryById.has(entryId)) {
+                            return;
+                        }
+                        rows.forEach((item) => item.classList.toggle('is-selected', item === row));
+                        const entry = entryById.get(entryId);
+                        updateDetail(entry);
+                    };
+
+                    rows.forEach((row) => {
+                        row.addEventListener('click', () => selectRow(row));
+                    });
+
+                    const preselected = rows.find((row) => row.classList.contains('is-selected'));
+                    if (preselected) {
+                        selectRow(preselected);
+                    } else if (rows.length > 0) {
+                        selectRow(rows[0]);
+                    }
+                }
+            }
         });
     </script>
 </body>

--- a/webUI/templates/industry/library.html
+++ b/webUI/templates/industry/library.html
@@ -1,5 +1,195 @@
 {% extends 'industry/layout.html' %}
 {% block title %}Blueprint Library{% endblock %}
+{% block extra_head %}
+<style>
+    .metrics.metrics--wide {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    .metric small {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 0.72rem;
+        color: var(--text-muted);
+    }
+
+    .library-layout {
+        display: grid;
+        grid-template-columns: minmax(460px, 1.35fr) minmax(340px, 1fr);
+        gap: 1.5rem;
+        align-items: start;
+    }
+
+    .library-table table tbody tr {
+        cursor: pointer;
+        transition: background 0.2s ease;
+    }
+
+    .library-table table tbody tr:hover {
+        background: rgba(56, 189, 248, 0.12);
+    }
+
+    .library-table table tbody tr.is-selected {
+        background: rgba(14, 165, 233, 0.22);
+        box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.4);
+    }
+
+    .library-table__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 1rem;
+        margin-bottom: 1rem;
+    }
+
+    .library-table__header span {
+        color: var(--text-muted);
+        font-size: 0.85rem;
+    }
+
+    .library-detail {
+        display: flex;
+        flex-direction: column;
+        gap: 1.2rem;
+        min-height: 100%;
+    }
+
+    .library-detail__empty {
+        text-align: center;
+        color: var(--text-muted);
+        padding: 2rem 1.5rem;
+        border: 1px dashed rgba(148, 163, 184, 0.25);
+        border-radius: 14px;
+        background: rgba(15, 23, 42, 0.3);
+    }
+
+    .detail-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 1rem;
+    }
+
+    .detail-header h2 {
+        margin: 0;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+    }
+
+    .detail-header h3 {
+        margin: 0.2rem 0 0;
+        font-size: 1.3rem;
+    }
+
+    .detail-header p {
+        margin: 0.2rem 0 0;
+        color: var(--text-muted);
+        font-size: 0.85rem;
+    }
+
+    .detail-badges {
+        display: flex;
+        gap: 0.5rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+    }
+
+    .detail-meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 1rem;
+    }
+
+    .detail-meta span {
+        display: block;
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+    }
+
+    .detail-meta strong {
+        display: block;
+        font-size: 1rem;
+        margin-top: 0.2rem;
+    }
+
+    .detail-metrics {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+    }
+
+    .detail-metric {
+        background: rgba(15, 23, 42, 0.45);
+        border-radius: 16px;
+        padding: 1rem;
+        border: 1px solid rgba(148, 163, 184, 0.18);
+    }
+
+    .detail-metric span {
+        text-transform: uppercase;
+        font-size: 0.7rem;
+        letter-spacing: 0.05em;
+        color: var(--text-muted);
+    }
+
+    .detail-metric strong {
+        display: block;
+        margin-top: 0.35rem;
+        font-size: 1.1rem;
+    }
+
+    .materials-table th,
+    .materials-table td {
+        font-size: 0.78rem;
+    }
+
+    .materials-table td.numeric {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .materials-table tbody tr.build-preferred td {
+        background: rgba(52, 211, 153, 0.12);
+    }
+
+    .materials-table tbody tr.build-more-expensive td {
+        background: rgba(248, 113, 113, 0.08);
+    }
+
+    .materials-footnote {
+        font-size: 0.75rem;
+        color: var(--text-muted);
+        margin-top: 0.6rem;
+    }
+
+    .materials-footnote.danger {
+        color: var(--danger);
+    }
+
+    .materials-missing {
+        margin: 0.6rem 0 0;
+        padding-left: 1.1rem;
+        color: var(--danger);
+        font-size: 0.8rem;
+    }
+
+    @media (max-width: 1180px) {
+        .library-layout {
+            grid-template-columns: 1fr;
+        }
+    }
+
+    @media (max-width: 720px) {
+        .metrics.metrics--wide {
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        }
+    }
+</style>
+{% endblock %}
 {% block content %}
     {% if not report or not report.library %}
         <div class="empty-state">
@@ -10,99 +200,232 @@
     {% else %}
         <section class="card">
             <h2>Library Summary</h2>
-            <div class="metrics">
+            <div class="metrics metrics--wide">
                 <div class="metric">
                     <span>Total Blueprints</span>
                     <strong>{{ report.summary.blueprint_total }}</strong>
+                    <small>Originals {{ report.summary.original_total }} • Copies {{ report.summary.copy_total }}</small>
                 </div>
                 <div class="metric">
-                    <span>Buildable</span>
+                    <span>Build Ready</span>
                     <strong>{{ report.summary.buildable_total }}</strong>
+                    <small>{{ report.summary.craftable_total }} craftable • {{ report.summary.unbuildable_total }} blocked</small>
                 </div>
                 <div class="metric">
-                    <span>Profitable</span>
+                    <span>Profitable Plans</span>
                     <strong>{{ report.summary.profitable_total }}</strong>
+                    <small>{{ report.summary.plan_total }} meet margin target</small>
                 </div>
                 <div class="metric">
-                    <span>Plan Ready</span>
-                    <strong>{{ report.summary.plan_total }}</strong>
+                    <span>Component Build Options</span>
+                    <strong>{{ report.summary.materials_with_build_option }}</strong>
+                    <small>{{ report.summary.materials_build_cheaper }} cheaper to build</small>
                 </div>
                 <div class="metric">
-                    <span>Craftable Today</span>
-                    <strong>{{ report.summary.craftable_total }}</strong>
+                    <span>Average Build Savings</span>
+                    <strong>{{ '{:,.2f}'.format(report.summary.average_build_savings) }}</strong>
+                    <small>Total savings {{ '{:,.2f}'.format(report.summary.total_build_savings) }}</small>
                 </div>
                 <div class="metric">
-                    <span>Avg ME / TE</span>
-                    <strong>{{ report.summary.average_me | round(1) }} / {{ report.summary.average_te | round(1) }}</strong>
+                    <span>Total Profit Potential</span>
+                    <strong>{{ '{:,.0f}'.format(report.summary.total_profit) }}</strong>
+                    <small>Avg ISK/hr {{ '{:,.2f}'.format(report.summary.average_isk_per_hour) }}</small>
                 </div>
             </div>
         </section>
-        <section class="card">
-            <h2>Blueprint Inventory</h2>
-            <div class="table-wrapper">
-                <table data-sortable="true" data-entry-selector="tr[data-entry-row='true']">
-                    <thead>
-                        <tr>
-                            <th data-type="string">Blueprint</th>
-                            <th data-type="string">Product</th>
-                            <th data-type="string">Character</th>
-                            <th data-type="number">Runs</th>
-                            <th data-type="number">ME</th>
-                            <th data-type="number">TE</th>
-                            <th data-type="number">Material Cost/run</th>
-                            <th data-type="number">Revenue/run</th>
-                            <th data-type="number">Profit/run</th>
-                            <th data-type="number">ISK/hr</th>
-                            <th data-type="string">Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for entry in report.library %}
-                            <tr data-entry-row="true" data-entry-id="{{ entry.blueprint_type_id }}">
-                                <td>{{ entry.blueprint_name }}</td>
-                                <td>{{ entry.product_name }}</td>
-                                <td>{{ entry.character_name }}</td>
-                                <td data-sort-value="{{ entry.available_runs if entry.available_runs is not none else (10 ** 9) }}">{{ entry.runs_display }}</td>
-                                <td data-sort-value="{{ entry.me }}">{{ entry.me }}</td>
-                                <td data-sort-value="{{ entry.te }}">{{ entry.te }}</td>
-                                <td data-sort-value="{{ entry.material_cost_per_run }}">{{ entry.material_cost_per_run | round(2) }}</td>
-                                <td data-sort-value="{{ entry.revenue_per_run }}">{{ entry.revenue_per_run | round(2) }}</td>
-                                <td data-sort-value="{{ entry.profit_per_run }}">{{ entry.profit_per_run | round(2) }}</td>
-                                <td data-sort-value="{{ entry.isk_per_hour }}">{{ entry.isk_per_hour | round(2) }}</td>
-                                <td>
-                                    {% if entry.can_build %}
-                                        <span class="badge success">Ready</span>
-                                    {% elif entry.total_runs == 0 %}
-                                        <span class="badge danger">No Runs Available</span>
-                                    {% else %}
-                                        <span class="badge danger">Missing Inputs</span>
-                                    {% endif %}
-                                </td>
+
+        <div class="library-layout">
+            <section class="card library-table">
+                <div class="library-table__header">
+                    <h2>Blueprint Inventory</h2>
+                    <span>{{ report.summary.blueprint_total }} entries</span>
+                </div>
+                <div class="table-wrapper">
+                    <table data-sortable="true" data-entry-selector="tr[data-entry-row='true']">
+                        <thead>
+                            <tr>
+                                <th data-type="string">Blueprint</th>
+                                <th data-type="string">Product</th>
+                                <th data-type="string">Character</th>
+                                <th data-type="number">Runs</th>
+                                <th data-type="number">Material Cost/run</th>
+                                <th data-type="number">Revenue/run</th>
+                                <th data-type="number">Profit/run</th>
+                                <th data-type="number">ISK/hr</th>
+                                <th data-type="number">Margin%</th>
+                                <th data-type="number">Build Options</th>
+                                <th data-type="string">Status</th>
                             </tr>
-                            {% if entry.materials %}
-                                <tr class="materials-row" data-details-for="{{ entry.blueprint_type_id }}">
-                                    <td colspan="11">
-                                        <strong>Materials per run</strong>
-                                        <ul class="materials-list">
-                                            {% for mat in entry.materials %}
-                                                <li>
-                                                    {{ mat.name }} — {{ mat.adjusted_quantity }} units @ {{ mat.price | round(2) }} ISK ({{ mat.total_cost | round(2) }} ISK)
-                                                    {% if not mat.available %}
-                                                        <span class="badge danger">No market price</span>
-                                                    {% endif %}
-                                                </li>
-                                            {% endfor %}
-                                        </ul>
-                                        {% if entry.missing_materials %}
-                                            <p class="badge danger">Missing inputs: {{ entry.missing_materials | join(', ') }}</p>
+                        </thead>
+                        <tbody>
+                            {% for entry in report.library %}
+                                {% set buildable_materials = entry.materials | selectattr('buildable', 'equalto', True) | list %}
+                                {% set preferred_materials = entry.materials | selectattr('build_preferred', 'equalto', True) | list %}
+                                <tr data-entry-row="true" data-entry-id="{{ entry.blueprint_type_id }}" class="{% if selected_entry and selected_entry.blueprint_type_id == entry.blueprint_type_id %}is-selected{% endif %}">
+                                    <td>{{ entry.blueprint_name }}</td>
+                                    <td>{{ entry.product_name }}</td>
+                                    <td>{{ entry.character_name }}</td>
+                                    <td data-sort-value="{{ entry.available_runs if entry.available_runs is not none else (10 ** 9) }}">{{ entry.runs_display }}</td>
+                                    <td data-sort-value="{{ entry.material_cost_per_run }}">{{ '{:,.2f}'.format(entry.material_cost_per_run) }}</td>
+                                    <td data-sort-value="{{ entry.revenue_per_run }}">{{ '{:,.2f}'.format(entry.revenue_per_run) }}</td>
+                                    <td data-sort-value="{{ entry.profit_per_run }}">{{ '{:,.2f}'.format(entry.profit_per_run) }}</td>
+                                    <td data-sort-value="{{ entry.isk_per_hour }}">{{ '{:,.2f}'.format(entry.isk_per_hour) }}</td>
+                                    <td data-sort-value="{{ entry.margin_percent }}">{{ '{:,.2f}'.format(entry.margin_percent * 100) }}%</td>
+                                    <td data-sort-value="{{ preferred_materials|length }}">
+                                        {% if buildable_materials %}
+                                            <span class="badge {% if preferred_materials|length > 0 %}success{% else %}neutral{% endif %}">
+                                                {{ preferred_materials|length }} / {{ buildable_materials|length }}
+                                            </span>
+                                        {% else %}
+                                            <span class="badge neutral">Market Buy</span>
+                                        {% endif %}
+                                    </td>
+                                    <td>
+                                        {% if entry.can_build %}
+                                            <span class="badge success">Ready</span>
+                                        {% elif entry.total_runs == 0 %}
+                                            <span class="badge danger">No Runs</span>
+                                        {% else %}
+                                            <span class="badge danger">Missing Inputs</span>
                                         {% endif %}
                                     </td>
                                 </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="card library-detail" id="library-detail" data-has-selection="{{ 'true' if selected_entry else 'false' }}">
+                {% if not selected_entry %}
+                    <div class="library-detail__empty">Select a blueprint from the table to inspect build details.</div>
+                {% else %}
+                    <header class="detail-header">
+                        <div>
+                            <h2>Blueprint Detail</h2>
+                            <h3 data-field="blueprint-name">{{ selected_entry.blueprint_name }}</h3>
+                            <p data-field="product-line">{{ selected_entry.product_name }} • {{ selected_entry.product_quantity }} units per run</p>
+                        </div>
+                        <div class="detail-badges">
+                            <span class="badge neutral" data-field="blueprint-kind">{{ 'Original Blueprint' if selected_entry.is_original else 'Copy Blueprint' }}</span>
+                            <span class="badge {% if selected_entry.can_build %}success{% else %}danger{% endif %}" data-field="status-badge">
+                                {% if selected_entry.can_build %}Build Ready{% elif selected_entry.total_runs == 0 %}No Runs Available{% else %}Missing Inputs{% endif %}
+                            </span>
+                        </div>
+                    </header>
+
+                    <div class="detail-meta">
+                        <div>
+                            <span>Character</span>
+                            <strong data-field="character-name">{{ selected_entry.character_name }}</strong>
+                        </div>
+                        <div>
+                            <span>Runs Available</span>
+                            <strong data-field="runs">{{ selected_entry.runs_display }}</strong>
+                        </div>
+                        <div>
+                            <span>Research (ME / TE)</span>
+                            <strong data-field="research">{{ selected_entry.me }} / {{ selected_entry.te }}</strong>
+                        </div>
+                        <div>
+                            <span>Total Build Time</span>
+                            <strong data-field="total-time">{{ '{:,.2f}'.format(selected_entry.total_time_hours) }} h</strong>
+                        </div>
+                    </div>
+
+                    <div class="detail-metrics">
+                        <div class="detail-metric">
+                            <span>Material Cost / run</span>
+                            <strong data-field="material-cost">{{ '{:,.2f}'.format(selected_entry.material_cost_per_run) }}</strong>
+                        </div>
+                        <div class="detail-metric">
+                            <span>Revenue / run</span>
+                            <strong data-field="revenue">{{ '{:,.2f}'.format(selected_entry.revenue_per_run) }}</strong>
+                        </div>
+                        <div class="detail-metric">
+                            <span>Profit / run</span>
+                            <strong data-field="profit">{{ '{:,.2f}'.format(selected_entry.profit_per_run) }}</strong>
+                        </div>
+                        <div class="detail-metric">
+                            <span>ISK per hour</span>
+                            <strong data-field="isk-per-hour">{{ '{:,.2f}'.format(selected_entry.isk_per_hour) }}</strong>
+                        </div>
+                        <div class="detail-metric">
+                            <span>Total Profit</span>
+                            <strong data-field="total-profit">{{ '{:,.2f}'.format(selected_entry.total_profit) }}</strong>
+                        </div>
+                        <div class="detail-metric">
+                            <span>Margin</span>
+                            <strong data-field="margin">{{ '{:,.2f}'.format(selected_entry.margin_percent * 100) }}%</strong>
+                        </div>
+                    </div>
+
+                    <div class="detail-materials">
+                        <h3>Material Breakdown</h3>
+                        <div class="table-wrapper">
+                            <table class="materials-table">
+                                <thead>
+                                    <tr>
+                                        <th>Material</th>
+                                        <th class="numeric">Qty</th>
+                                        <th class="numeric">Market / unit</th>
+                                        <th class="numeric">Market total</th>
+                                        <th class="numeric">Build / unit</th>
+                                        <th class="numeric">Build total</th>
+                                        <th class="numeric">Savings</th>
+                                    </tr>
+                                </thead>
+                                <tbody data-materials-body>
+                                    {% for material in selected_entry.materials %}
+                                        {% set row_class = '' %}
+                                        {% if material.build_preferred %}
+                                            {% set row_class = row_class + ' build-preferred' %}
+                                        {% elif material.savings_vs_market is not none and material.savings_vs_market < 0 %}
+                                            {% set row_class = row_class + ' build-more-expensive' %}
+                                        {% endif %}
+                                        <tr class="{{ row_class.strip() }}">
+                                            <td>{{ material.name }}</td>
+                                            <td class="numeric">{{ material.adjusted_quantity }}</td>
+                                            <td class="numeric">{{ '{:,.2f}'.format(material.price) if material.price else '—' }}</td>
+                                            <td class="numeric">{{ '{:,.2f}'.format(material.total_cost) if material.total_cost else '—' }}</td>
+                                            <td class="numeric">
+                                                {% if material.build_cost_per_unit is not none %}
+                                                    {{ '{:,.2f}'.format(material.build_cost_per_unit) }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                            <td class="numeric">
+                                                {% if material.build_cost_total is not none %}
+                                                    {{ '{:,.2f}'.format(material.build_cost_total) }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                            <td class="numeric">
+                                                {% if material.savings_vs_market is not none %}
+                                                    {{ '{:,.2f}'.format(material.savings_vs_market) }}
+                                                {% else %}
+                                                    —
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="materials-footnote" data-missing-list>
+                            {% if selected_entry.missing_materials %}
+                                Missing inputs: {{ selected_entry.missing_materials | join(', ') }}
+                            {% else %}
+                                All required materials have market coverage.
                             {% endif %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </section>
+                        </div>
+                    </div>
+                {% endif %}
+            </section>
+        </div>
+
+        <script id="library-data" type="application/json">{{ library_data_json | safe }}</script>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- add build-vs-buy cost tracking to the industry analysis report and expose savings metrics
- expose the library dataset as JSON for the template and present an interactive blueprint detail panel
- enhance the shared layout script and styling so selecting a blueprint refreshes metrics and material breakdowns

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_690545b9b350832f802d6b2f3cb7c265