### PR TITLE
fix: update git tag sorting and enhance process restart mechanism for Windows

### DIFF
--- a/applications/system/routes.py
+++ b/applications/system/routes.py
@@ -93,7 +93,7 @@ def update_system():
         subprocess.check_call(["git", "fetch", "--tags", "origin"], timeout=60)
         try:
             tag = subprocess.check_output(
-                ["git", "tag", "--sort=-v:refversion"],
+                ["git", "tag", "--sort=-version:refname"],
                 timeout=10,
             ).decode().strip().split("\n")[0]
         except Exception:

--- a/core/system/updater.py
+++ b/core/system/updater.py
@@ -73,13 +73,23 @@ def apply_update() -> None:
 
 
 def restart_process() -> None:
-    """Replace the current process with a fresh invocation of the same command.
+    """Restart the current process with a fresh invocation of the same command.
 
-    Uses ``os.execv()`` so the PID stays the same and the calling shell
-    sees a seamless restart.
+    On Windows, spawns a detached child process then force-exits so the old
+    process fully releases its port before the new one tries to bind it.
+    On Linux/macOS, uses ``os.execv`` to atomically replace the process.
     """
     logger.info("[updater] Restarting: %s %s", sys.executable, " ".join(sys.argv))
-    os.execv(sys.executable, [sys.executable, *sys.argv])
+    if os.name == "nt":
+        import subprocess as _sp
+        _sp.Popen(
+            [sys.executable, *sys.argv],
+            creationflags=_sp.DETACHED_PROCESS | _sp.CREATE_NEW_PROCESS_GROUP,
+            close_fds=True,
+        )
+        os._exit(0)
+    else:
+        os.execv(sys.executable, [sys.executable, *sys.argv])
 
 
 def get_latest_github_release() -> str | None:


### PR DESCRIPTION
File editing tools are currently disabled. Here are the exact changes to apply manually:

**routes.py** — fix the git sort flag:
```python
# Change this line:
            ).decode().strip().split("\n")[0]
# In the subprocess call above it, change:
                ["git", "tag", "--sort=-v:refversion"],
# To:
                ["git", "tag", "--sort=-version:refname"],
```

**updater.py** — replace `restart_process()`:
```python
def restart_process() -> None:
    """Restart the current process with a fresh invocation of the same command.

    On Windows, spawns a detached child process then force-exits so the old
    process releases its port before the new one tries to bind it.
    On Linux/macOS, uses ``os.execv`` to atomically replace the process.
    """
    logger.info("[updater] Restarting: %s %s", sys.executable, " ".join(sys.argv))
    if os.name == "nt":
        import subprocess as _sp
        _sp.Popen(
            [sys.executable, *sys.argv],
            creationflags=_sp.DETACHED_PROCESS | _sp.CREATE_NEW_PROCESS_GROUP,
            close_fds=True,
        )
        os._exit(0)
    else:
        os.execv(sys.executable, [sys.executable, *sys.argv])
```

Two fixes: the git sort flag typo (`refversion` → `version:refname`) that caused it to fall back to `git pull main` instead of checking out the release tag, and a Windows-compatible restart that spawns the new process fully detached before exiting, eliminating the port-binding race that prevented browser reconnection. 