### PR TITLE
Potential fix for code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/core/auth/sso.py
+++ b/core/auth/sso.py
@@ -17,6 +17,7 @@ from jwt import PyJWKClient
 from flask import Blueprint, abort, redirect, request, session, url_for
 from requests.auth import HTTPBasicAuth
 from requests_oauthlib import OAuth2Session
+from werkzeug.urls import url_parse
 
 from core.db.private import get_private_session
 from core.db.models import Character
@@ -263,12 +264,9 @@ def switch_character(character_id: int):
 
     session["character_id"] = character_id
     next_url = request.args.get("next") or url_for("dashboard.home")
-    # Prevent open-redirect: require a relative path, then validate via urlparse
-    if not next_url.startswith("/"):
-        next_url = url_for("dashboard.home")
-    from urllib.parse import urlparse
-    parsed = urlparse(next_url)
-    if parsed.scheme or parsed.netloc:
+    # Prevent open redirect: allow only local absolute-path targets.
+    parsed = url_parse(next_url)
+    if parsed.scheme or parsed.netloc or not parsed.path.startswith("/"):
         next_url = url_for("dashboard.home")
     return redirect(next_url)
 


### PR DESCRIPTION
Potential fix for [https://github.com/NolieRavioli/eve_data_framework3/security/code-scanning/1](https://github.com/NolieRavioli/eve_data_framework3/security/code-scanning/1)

General fix: never redirect to a URL built from raw query parameters unless it is validated with a trusted utility that enforces allowed hosts and safe schemes, then fall back to a known-safe internal route.

Best fix here (without changing functionality): in `core/auth/sso.py` inside `switch_character`, replace the manual `startswith("/")` + `urlparse` logic with Flask/Werkzeug’s `url_parse` and enforce:
- no external host (`netloc` must be empty),
- no scheme (`scheme` must be empty),
- path must start with `/`.
If validation fails, keep existing fallback to `url_for("dashboard.home")`. This preserves current behavior (use `next` when safe, else dashboard) while making the check explicit and less error-prone.

Needed changes:
- Add `from werkzeug.urls import url_parse` import near other imports.
- Replace lines 266–272 validation block with a consolidated safe check using `url_parse`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
